### PR TITLE
Fix optional field validation

### DIFF
--- a/flatforge/rules/validation/date.py
+++ b/flatforge/rules/validation/date.py
@@ -42,8 +42,15 @@ class DateRule(ValidationRule):
         Raises:
             ValidationError: If the date is invalid or out of range
         """
+        value = str(field_value.value)
+
+        # Skip validation for empty values.  The RequiredRule should be used if
+        # the field must contain a value.
+        if value == "":
+            return
+
         try:
-            date = datetime.datetime.strptime(str(field_value.value), self.format).date()
+            date = datetime.datetime.strptime(value, self.format).date()
             
             if self.min_date and date < self.min_date:
                 raise ValidationError(

--- a/flatforge/rules/validation/string_length.py
+++ b/flatforge/rules/validation/string_length.py
@@ -37,6 +37,12 @@ class StringLengthRule(ValidationRule):
             ValidationError: If the field length is invalid
         """
         value = str(field_value.value)
+
+        # Skip validation for empty values.  If the field must not be empty
+        # a RequiredRule should be used in addition to this rule.
+        if value == "":
+            return
+
         length = len(value)
         
         if self.exact_length is not None and length != self.exact_length:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths =
+    tests
+    test_cli.py


### PR DESCRIPTION
## Summary
- ignore empty values in DateRule and StringLengthRule
- add pytest configuration to avoid collecting sample scripts as tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684356da252c8328adef072425ad2fe9